### PR TITLE
Fixed the time zone to UTC

### DIFF
--- a/src/result-verifier.js
+++ b/src/result-verifier.js
@@ -17,8 +17,8 @@ function validate(tweets, window) {
 
 function verify() {
     const window = {
-        start: moment(config.firstDay).valueOf(),
-        end: moment(config.lastDay).valueOf()
+        start: moment.utc(config.firstDay).valueOf(),
+        end: moment.utc(config.lastDay).valueOf()
     };
     const actualData = JSON.parse(fs.readFileSync(config.tweetsFile));
     const expectedData = JSON.parse(fs.readFileSync(config.expectedFile));

--- a/src/tweets-datastore.js
+++ b/src/tweets-datastore.js
@@ -77,8 +77,8 @@ function sendRequest(start, end, lastDay) {
 }
 
 sendRequest(
-    moment(FIRST_DAY_INCLUSIVE),
-    moment(FIRST_DAY_INCLUSIVE).add(DATE_INCREMENT, 'd'),
-    moment(LAST_DAY_EXCLUSIVE).valueOf()
+    moment.utc(FIRST_DAY_INCLUSIVE),
+    moment.utc(FIRST_DAY_INCLUSIVE).add(DATE_INCREMENT, 'd'),
+    moment.utc(LAST_DAY_EXCLUSIVE).valueOf()
 );
 


### PR DESCRIPTION
I just realized the start date doesn't get converted to UTC correctly which causes 8 hours off. Actually, this problem is introduced when I refactored out the configuring settings to a new file. Fixed the time zone by calling moment#utc method. 